### PR TITLE
Phase 8.5: Update CSP headers for Stripe and jsDelivr

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; connect-src 'self' https://api.getbrikk.com https://js.stripe.com https://hooks.stripe.com; script-src 'self' 'unsafe-inline' https://js.stripe.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.stripe.com https://cdn.jsdelivr.net; frame-src 'self' https://js.stripe.com https://hooks.stripe.com
+  Content-Security-Policy: default-src 'self'; connect-src 'self' https://api.getbrikk.com https://api.stripe.com https://js.stripe.com https://jsdelivr.net https://cdn.jsdelivr.net; frame-src https://js.stripe.com https://hooks.stripe.com; script-src 'self' 'unsafe-inline' https://js.stripe.com https://jsdelivr.net https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.stripe.com https://cdn.jsdelivr.net; frame-src 'self' https://js.stripe.com https://hooks.stripe.com
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
   Referrer-Policy: no-referrer-when-downgrade


### PR DESCRIPTION
## Changes

- Updated `_headers` CSP configuration to include:
  - `https://api.stripe.com` in `connect-src`
  - `https://jsdelivr.net` and `https://cdn.jsdelivr.net` in `connect-src` and `script-src`

## Purpose

Ensures Stripe checkout and jsDelivr CDN resources load without CSP violations.

## Related to

Phase 8.5-9.0 deliverables for Agent↔Agent demo